### PR TITLE
Fix deadlock caused when the same MessageBus is used in two separate tests

### DIFF
--- a/mockroservices-dotnet/Tests/MessageBusTest.cs
+++ b/mockroservices-dotnet/Tests/MessageBusTest.cs
@@ -15,6 +15,7 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace VaughnVernon.Mockroservices
 {
@@ -43,7 +44,7 @@ namespace VaughnVernon.Mockroservices
         [TestMethod]
         public void TestTopicPubSub()
         {
-            MessageBus messageBus = MessageBus.Start("test_bus");
+            MessageBus messageBus = MessageBus.Start("test_bus2");
             Topic topic = messageBus.OpenTopic("test_topic");
             MessageBusTestSubscriber subscriber = new MessageBusTestSubscriber();
             topic.Subscribe(subscriber);


### PR DESCRIPTION
The deadlock happens when all tests are run at once